### PR TITLE
Fix quoting bug in darwin overlay

### DIFF
--- a/modules/darwin/nivApps/default.nix
+++ b/modules/darwin/nivApps/default.nix
@@ -12,8 +12,8 @@ in
         if builtins.pathExists f
         then import f
         else {};
-      hm = pkgs.callPackage "${self.inputs.home-manager}/modules/files.nix" {
-        lib = lib // self.inputs.home-manager.lib;
+      hm = pkgs.callPackage "${self.inputs."home-manager"}/modules/files.nix" {
+        lib = lib // self.inputs."home-manager".lib;
       };
       hdiutil = hm.config.lib.file.mkOutOfStoreSymlink "/usr/bin/hdiutil";
     in (import ./niv-managed-dmg-apps.nix {


### PR DESCRIPTION
## Summary
- fix quoting for the `home-manager` attribute in darwin nivApps module

## Testing
- `git status --short`