### PR TITLE
Add flake checks

### DIFF
--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -1,0 +1,15 @@
+name: Flake checks
+
+on:
+  pull_request:
+  push:
+    branches: [ master ]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v22
+      - name: Run flake checks
+        run: nix flake check --show-trace

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# NixOS Configurations
+
+This repository uses Nix flakes. Development environments and formatting are provided via `nix develop` and `treefmt`.
+
+## Running checks
+
+Use `nix flake check` to evaluate system configurations (e.g., `linux-builder`) and ensure formatting is correct. The same checks run automatically for pull requests via GitHub Actions.

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
           (fn: ./modules/flake-parts/${fn})
           (attrNames (readDir ./modules/flake-parts)));
 
-      perSystem = { lib, system, ... }: {
+      perSystem = { lib, system, config, ... }: {
         # Make our overlay available to the devShell
         # "Flake parts does not yet come with an endorsed module that initializes the pkgs argument."
         # So we must do this manually; https://flake.parts/overlays#consuming-an-overlay
@@ -43,6 +43,9 @@
           overlays = lib.attrValues self.overlays;
           config.allowUnfree = true;
         };
+
+        checks.linux-builder = self.nixosConfigurations.linux-builder.config.system.build.toplevel;
+        checks.formatting = config.treefmt.build.check;
       };
     };
 }

--- a/modules/flake-parts/devshell.nix
+++ b/modules/flake-parts/devshell.nix
@@ -19,5 +19,7 @@
       projectRootFile = "flake.nix";
       programs.nixpkgs-fmt.enable = true;
     };
+
+    checks.formatting = config.treefmt.build.check;
   };
 }


### PR DESCRIPTION
## Summary
- add formatting check in devshell module
- run linux-builder and formatting checks from `flake.nix`
- document `nix flake check` usage in new README
- add GH Actions workflow to run flake checks

## Testing
- `nix flake check` *(fails: `nix: command not found`)*
- `treefmt --version` *(fails: `command not found`)*