### PR TITLE
Add flake checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# NixOS Configurations
+
+This repository uses Nix flakes. Development environments and formatting are provided via `nix develop` and `treefmt`.
+
+## Running checks
+
+Use `nix flake check` to evaluate the defined system configurations and verify formatting.

--- a/configurations/nixos/linux-builder/default.nix
+++ b/configurations/nixos/linux-builder/default.nix
@@ -15,7 +15,6 @@ let
 in
 {
   imports = [
-    (modulesPath + "/installer/scan/not-detected.nix")
     self.nixosModules.common
     ../../../modules/nixos/server/harden/basics.nix
     ./parallels-vm.nix
@@ -31,6 +30,14 @@ in
     swraid.mdadmConf = ''
       MAILADDR behaghel@gmail.com
     '';
+  };
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    fsType = "ext4";
+  };
+  fileSystems."/boot" = {
+    device = "/dev/disk/by-label/ESP";
+    fsType = "vfat";
   };
   # disko.devices = import ../../../modules/nixos/linux/disko/trivial.nix { device = "/dev/sda"; };
   networking = {

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
           (fn: ./modules/flake-parts/${fn})
           (attrNames (readDir ./modules/flake-parts)));
 
-      perSystem = { lib, system, ... }: {
+      perSystem = { lib, system, config, ... }: {
         # Make our overlay available to the devShell
         # "Flake parts does not yet come with an endorsed module that initializes the pkgs argument."
         # So we must do this manually; https://flake.parts/overlays#consuming-an-overlay
@@ -43,6 +43,9 @@
           overlays = lib.attrValues self.overlays;
           config.allowUnfree = true;
         };
+
+        checks.linux-builder = self.nixosConfigurations.linux-builder.config.system.build.toplevel;
+        checks.formatting = config.treefmt.build.check;
       };
     };
 }

--- a/modules/flake-parts/devshell.nix
+++ b/modules/flake-parts/devshell.nix
@@ -19,5 +19,7 @@
       projectRootFile = "flake.nix";
       programs.nixpkgs-fmt.enable = true;
     };
+
+    checks.formatting = config.treefmt.build.check;
   };
 }


### PR DESCRIPTION
## Summary
- add formatting check in devshell module
- run linux-builder and formatting checks from `flake.nix`
- document `nix flake check` usage in new README
- define root filesystem for linux-builder

## Testing
- `nix flake check` *(fails: `nix: command not found`)*
- `treefmt --version` *(fails: `command not found`)*