### PR TITLE
Add alejandra formatter and git hook

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.nix]
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # NixOS Configurations
 
-This repository uses Nix flakes. Development environments and formatting are provided via `nix develop` and `treefmt`.
+This repository uses Nix flakes. Development environments and formatting are provided via `nix develop` and `treefmt` with the [Alejandra](https://github.com/kamadorueda/alejandra) formatter.
+
+An `.editorconfig` file defines the coding style so that editors can enforce it while editing.
+
+Git hooks are stored in the `githooks` directory. Point `core.hooksPath` to this folder to automatically format code after each commit:
+
+```bash
+git config core.hooksPath githooks
+```
 
 ## Running checks
 

--- a/githooks/post-commit
+++ b/githooks/post-commit
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+nix fmt >/dev/null || true
+
+if ! git diff --quiet; then
+  echo "warning: code formatted after commit. Please review and commit the changes." >&2
+fi

--- a/modules/flake-parts/devshell.nix
+++ b/modules/flake-parts/devshell.nix
@@ -17,7 +17,7 @@
 
     treefmt.config = {
       projectRootFile = "flake.nix";
-      programs.nixpkgs-fmt.enable = true;
+      programs.alejandra.enable = true;
     };
 
     checks.formatting = config.treefmt.build.check;


### PR DESCRIPTION
## Summary
- enforce nix style via alejandra
- add .editorconfig for consistent formatting
- document hook configuration in README
- run alejandra via treefmt
- provide git post-commit hook that auto-formats and warns on changes

## Testing
- `git status --short`