### PR TITLE
Remove obsolete dotfiles references

### DIFF
--- a/modules/home/darwin/bepo.nix
+++ b/modules/home/darwin/bepo.nix
@@ -1,9 +1,3 @@
-{lib, ...}:
-{
-  home.activation = {
-    # macos doesn't support symlink for keyboard layouts
-    copyBepoLayout = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-                       $DRY_RUN_CMD cp ".dotfiles/macos/Library/Keyboard Layouts/bepo.keylayout" $HOME/Library/Keyboard\ Layouts
-      '';
-  };
-}
+{ lib, ... }:
+
+{}

--- a/modules/home/shell/default.nix
+++ b/modules/home/shell/default.nix
@@ -73,9 +73,5 @@ in
     myHomeDirs = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
                   $DRY_RUN_CMD mkdir -p $HOME/.local/share $HOME/tmp $HOME/ws;  ln -sfn ${pkgs.mu}/share/emacs $HOME/.local/share
                 '';
-    # link emacs, vim and password-store: git submodules don't work with home.file (they are empty)
-    # linkHomeConfigs = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    #               $DRY_RUN_CMD ln -sf .dotfiles/vim/.vim; ln -sf .dotfiles/emacs/.emacs.d; ln -sf .dotfiles/pass/.password-store
-    #   '';
   };
 }


### PR DESCRIPTION
## Summary
- remove use of external `.dotfiles` path in the macOS Bepo module
- drop commented dotfiles links from shell activation

## Testing
- `nix flake check` *(fails: `nix` command not found)*